### PR TITLE
docker: change the production port back to 8080

### DIFF
--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -8,7 +8,7 @@ services:
     stdin_open: true
     tty: true
     ports:
-      - 8080:80
+      - 8080:8080
     volumes:
       - persistent:/persistent:z
 

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -49,4 +49,4 @@ RUN npx shadow-cljs release app
 # https://www.uvicorn.org/deployment/
 WORKDIR /src/backend
 ENV PYTHONPATH="${PYTHONPATH}:/src"
-CMD gunicorn -k uvicorn.workers.UvicornWorker api:app -b 0.0.0.0:80
+CMD gunicorn -k uvicorn.workers.UvicornWorker api:app -b 0.0.0.0:8080


### PR DESCRIPTION
Reverts 813c34b (PR #31)

We cannot have our production container listening on the port 80 because it is deployed in OpenShift and we can't use privileged ports there:

    [2023-11-29 20:55:17 +0000] [1] [INFO] Starting gunicorn 20.1.0
    [2023-11-29 20:55:17 +0000] [1] [ERROR] Retrying in 1 second.
    [2023-11-29 20:55:18 +0000] [1] [ERROR] Retrying in 1 second.
    [2023-11-29 20:55:19 +0000] [1] [ERROR] Retrying in 1 second.
    [2023-11-29 20:55:20 +0000] [1] [ERROR] Retrying in 1 second.
    [2023-11-29 20:55:21 +0000] [1] [ERROR] Retrying in 1 second.
    [2023-11-29 20:55:54 +0000] [1] [ERROR] Can't connect to ('0.0.0.0', 80)

Instead we want to have an OpenShift route from public 80 to container
8080. And I finally understand the point of PR #31, it was to fix the production container for docker-compose, so I am fixing the route there as well.