### PR TITLE
Strip prefix and suffix whitespace chars from input parameters

### DIFF
--- a/frontend/src/app/homepage.cljs
+++ b/frontend/src/app/homepage.cljs
@@ -24,7 +24,7 @@
                       "#koji"   [(get @input-values :koji-build-id)
                                  (get @input-values :koji-arch)]
                       "#url"    [(js/btoa (get @input-values :url))])
-        url (str/join "/" (concat ["/contribute" source] params))]
+        url (str/join "/" (concat ["/contribute" source] (map str/trim params)))]
     (when (empty? @input-errors)
       (set! (.-href (.-location js/window)) url))))
 


### PR DESCRIPTION
Leading and trailing white space will be trimmed, before parameters are passed to the backend.

This should simplify copy and pasting of parameters into the search box.