### PR TITLE
backend: dont pass NoneType to os.path.dirname in case baseurl is None

### DIFF
--- a/backend/fetcher.py
+++ b/backend/fetcher.py
@@ -86,7 +86,7 @@ class CoprProvider(Provider):
 
         if self.chroot == "srpm-builds":
             build = self.client.build_proxy.get(self.build_id)
-            baseurl = os.path.dirname(build.source_package["url"])
+            baseurl = os.path.dirname(build.source_package.get("url", ""))
         else:
             build_chroot = self.client.build_chroot_proxy.get(
                 self.build_id, self.chroot


### PR DESCRIPTION
#39 with that example build has no build to fetch - but instead of `There are no results...` response we got some weird traceback

Fixes #39