### PR TITLE
docker: don't preinstall JavaScript and ClojureScript dependencies

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,7 +27,11 @@ services:
       dockerfile: docker/frontend/Dockerfile
     hostname: frontend
     working_dir: /opt/log-detective-website/frontend
-    command: "npx shadow-cljs watch app"
+    command: >
+      bash -c "
+        npm install &&
+        npx shadow-cljs watch app
+      "
     stdin_open: true
     tty: true
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
       dockerfile: docker/backend/Dockerfile
     hostname: backend
     working_dir: /opt/log-detective-website/backend
-    command: "uvicorn api:app --host 0.0.0.0 --port 5020"
+    command: "uvicorn api:app --host 0.0.0.0 --port 5020 --reload"
     stdin_open: true
     tty: true
     ports:

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -20,14 +20,23 @@ RUN dnf -y update && \
                    java \
     && dnf clean all
 
-# We cannot use volumes to bindmount code from the host during the build phase.
-# We need to copy them.
-COPY ./ /src/code/
-
-WORKDIR /src/code/frontend
-RUN npm install
 RUN npm install -g shadow-cljs
 
+# TODO In the next steps we want to copy the source code to the container,
+# install all Javascript dependencies and pre-install all ClojureScript
+# dependencies. However we want to make them available to the bind-mounted
+# directory in /opt/log-detective-website that will be used when running the
+# container. Unfortunatelly, I don't know how to do that, which makes running
+# the container for the first time take a couple of minutes before it is ready.
+# To whomever trying to fix this, here are some useful commands:
+#
+# We cannot use volumes to bindmount code from the host during the build phase.
+# We need to copy them.
+# COPY ./ /src/code/
+#
+# WORKDIR /src/code/frontend
+# RUN npm install
+#
 # Unintuitive command but it downloads all ClojureScript dependencies
 # https://github.com/thheller/shadow-cljs/issues/362
-RUN npx shadow-cljs classpath
+# RUN npx shadow-cljs classpath

--- a/frontend/public/layout.html
+++ b/frontend/public/layout.html
@@ -76,7 +76,7 @@
 
     {%block content %} {% endblock %}
 
-    <script src="/js/main.js" type="text/javascript"></script>
+    <script src="/static/js/main.js" type="text/javascript"></script>
     <script
       src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"
       integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz"


### PR DESCRIPTION
That would install them only to initial source code built into the container image and wouldn't make them available for the bind-mounted sources during the container runtime. Please see more details in the code comment.

This commit fixes our `The required namespace "react" is not available, it was required by "reagent/core.cljs"` issue.