### PR TITLE
Download collected data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
+COMPOSE ?= $(shell command -v podman-compose 2> /dev/null || echo docker-compose)
+
+
 build-prod:
-	docker-compose -f docker-compose.prod.yaml build --no-cache
+	$(COMPOSE) -f docker-compose.prod.yaml build --no-cache
 
 # don't forget to log in to quay.io
 push-prod:
-	docker-compose -f docker-compose.prod.yaml push
+	$(COMPOSE) -f docker-compose.prod.yaml push

--- a/backend/spells.py
+++ b/backend/spells.py
@@ -3,6 +3,7 @@ Some random spells and helpers for backend :magic:
 """
 
 import shutil
+import tarfile
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
@@ -16,3 +17,22 @@ def get_temporary_dir() -> Iterator[Path]:
         yield temp_dir
     finally:
         shutil.rmtree(temp_dir)
+
+
+def make_tar(name: str, source: Path, destination: Path) -> Path:
+    """
+    Make tar from source path.
+
+    Args:
+        name: Name of the tar file
+        source: Source to be tarred
+        destination: Folder where to put tar file
+
+    Returns:
+        Path where to find a tar file.
+    """
+    tar_path = destination / name
+    with tarfile.open(tar_path, "w:gz") as tar_f:
+        tar_f.add(source, arcname=name)
+
+    return tar_path

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -3,7 +3,8 @@ services:
   website:
     build:
       context: docker/production
-    image: quay.io/jkadlcik/log-detective
+      dockerfile: Dockerfile
+    image: quay.io/log-detective/website
     hostname: log-detective
     stdin_open: true
     tty: true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,10 +14,12 @@ services:
     volumes:
       - .:/opt/log-detective-website:z
       - persistent:/persistent
+    env_file:
+      - "files/env"
     environment:
       - ENV=devel
-      - FEEDBACK_DIR=/persistent/results
       - PYTHONPATH=/opt/log-detective-website
+
   # The frontend container is only a quality of life for development.
   # For production, we will simply compile the ClojureScript into JavaScript
   # and deploy it.
@@ -40,9 +42,10 @@ services:
       - 3333:3333
     volumes:
       - .:/opt/log-detective-website:z
+    env_file:
+      - "files/env"
     environment:
       - ENV=devel
-      - FEEDBACK_DIR=/persistent/results
 
 volumes:
   persistent:

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -1,24 +1,11 @@
 FROM registry.fedoraproject.org/fedora:38
 MAINTAINER copr-devel@lists.fedorahosted.org
 
-ENV FEEDBACK_DIR=/persistent/results
 ENV ENV=production
 
 RUN dnf -y update && \
     # Base packages
-    dnf -y install htop \
-                   make \
-                   wget \
-                   net-tools \
-                   iputils \
-                   vim \
-                   mlocate \
-                   jq \
-                   fpaste \
-                   git \
-                   sudo \
-                   python3-ipdb \
-                   findutils \
+    dnf -y install git \
     # Frontend
     && dnf -y install \
                    npm \
@@ -36,8 +23,11 @@ RUN npx shadow-cljs release app
 FROM registry.fedoraproject.org/fedora:38
 MAINTAINER copr-devel@lists.fedorahosted.org
 
-ENV FEEDBACK_DIR=/persistent/results
 ENV ENV=production
+
+# TODO: how to get envs from env file in openshift?
+ENV STORAGE_DIR=/persistent
+ENV FEEDBACK_DIR=/persistent/results
 
 RUN dnf -y install python3-fastapi \
                    python3-uvicorn \
@@ -47,8 +37,22 @@ RUN dnf -y install python3-fastapi \
                    python3-koji \
                    python3-copr \
                    koji \
+                   htop \
+                   btop \
+                   make \
+                   wget \
+                   net-tools \
+                   iputils \
+                   vim \
+                   mlocate \
+                   jq \
+                   fpaste \
+                   git \
+                   python3-ipdb \
+                   findutils \
     && dnf clean all \
     && mkdir -p /src/{frontend,backend}
+
 COPY --from=0 /src/frontend/public /src/frontend/public
 COPY --from=0 /src/backend /src/backend
 

--- a/files/env
+++ b/files/env
@@ -1,0 +1,2 @@
+STORAGE_DIR=/persistent
+FEEDBACK_DIR=/persistent/results

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -55,6 +55,14 @@
         logs or reviewing the data we already have.
       </div>
     </div>
+
+    <div class="card">
+      <div class="card-body">
+        <h5 class="card-title">Download collected data</h5>
+        Are you interested in the data we received from users? You can download them
+        <a href="/download">here</a>.
+      </div>
+    </div>
   </div>
 </div>
 

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -42,11 +42,23 @@ Build the container image:
 docker-compose -f docker-compose.prod.yaml build --no-cache
 ```
 
+or
+
+```bash
+make build-prod
+```
+
 Push the image to quay.io
-[quay.io/jkadlcik/log-detective][quay-repo]:
+[quay.io/log-detective][quay-organization]:
 
 ```
 docker-compose -f docker-compose.prod.yaml push
+```
+
+or
+
+```bash
+make push-prod
 ```
 
 Make sure you are using the correct OpenShift project
@@ -77,7 +89,7 @@ oc logs -f deploy/log-detective-website
 oc rsh deploy/log-detective-website
 ```
 
-[quay-repo]: https://quay.io/repository/jkadlcik/log-detective
+[quay-organization]: https://quay.io/repository/log-detective/website
 [group1]: https://accounts.fedoraproject.org/group/communishift/
 [group2]: https://accounts.fedoraproject.org/group/communishift-log-detective/
 

--- a/openshift/log-detective.yaml
+++ b/openshift/log-detective.yaml
@@ -18,7 +18,7 @@ spec:
             claimName: persistent
       containers:
         - name: log-detective-website
-          image: quay.io/jkadlcik/log-detective:latest
+          image: quay.io/log-detective/website:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Fixes #49

This solution raises two concerns for the future once we have a
lot of data collected:
- it will be a while until the data will be tarred - creating delay before
  actual download (after cca 200 feedbacks relly noticable delay :/)
  look at example with only 300 (tiny!!) feedbacks:
  ```
  [root@backend persistent]# time tar -zcf results.tar.gz results/
  real m9.473s
  user m9.328s
  sys m0.483s
  ```
- downloading takes also some time

-> thus blocking the whole worker during this. IIRC we have 8 workers thus
8 downloads and API is unresponsive.

Solution:
- how to solve the delay before download:
  https://github.com/fedora-copr/log-detective-website/issues/64
- the issue above is the slowest, once that will be resolved and people
  still complain, do this:
  https://github.com/fedora-copr/log-detective-website/issues/65

This also creates good base for resolving #33 - only thing needed is to periodically download the data to somewhere.