### PR TITLE
fix fetching SRPM build logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ COMPOSE ?= $(shell command -v podman-compose 2> /dev/null || echo docker-compose
 build-prod:
 	$(COMPOSE) -f docker-compose.prod.yaml build --no-cache
 
+up-prod:
+	$(COMPOSE) -f docker-compose.prod.yaml up
+
 # don't forget to log in to quay.io
 push-prod:
 	$(COMPOSE) -f docker-compose.prod.yaml push

--- a/backend/constants.py
+++ b/backend/constants.py
@@ -7,6 +7,9 @@ KOJI_BUILD_URL = "https://koji.fedoraproject.org/koji/buildinfo?buildID={0}"
 PACKIT_BUILD_URL = "https://dashboard.packit.dev/jobs/copr-builds"
 FEEDBACK_DIR = os.environ.get("FEEDBACK_DIR", "/var/lib/builds/feedbacks")
 
+COPR_RESULT_TEMPLATE = "https://download.copr.fedorainfracloud.org" + \
+                       "/results/{0}/{1}/srpm-builds/{2:08}"
+
 
 class ProvidersEnum(StrEnum):
     packit = "packit"


### PR DESCRIPTION
Cheers @FrostyX
https://github.com/fedora-copr/log-detective-website/issues/73#issuecomment-1889042206

Fixes #73

Verified and I was finally able to fetch the failed SRPM build log.

One problem though is that the build didn't have the spec file uploaded so I
had to change the logic with upload specs to not require one.