### PR TITLE
Adding video demonstration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+log_detective_demo.gif filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Production instance: http://log-detective.com
 
-## Screenshot
+## DEMO
 
-![Screenshot](screenshot.png)
+![Video](./log_detective_demo.gif)
 
 ## Development
 

--- a/log_detective_demo.gif
+++ b/log_detective_demo.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b36d81249a0076f3b7dd1650b996d8d6cdca20ebd1d684a0c9a4cff0569ffc7
+size 24905850


### PR DESCRIPTION
Technically this does count as a large file.
Therefore it is now tracked by git-lfs[0] to simplify repo management. In practice it makes very little difference.
Now if it was 3GB, that would be a problem.

[0] https://git-lfs.com/

Co-authored-by: Jakub Kadlčík