### PR TITLE
correctly obtain failed koji build logs

### DIFF
--- a/backend/fetcher.py
+++ b/backend/fetcher.py
@@ -252,7 +252,10 @@ class KojiProvider(RPMProvider):
 
         if self.task_info["method"] != "buildArch":
             raise HTTPException(
-                detail=f"{self.build_or_task_id} is not buildArch method.",
+                detail=(
+                    f"Task {self.build_or_task_id} method is "
+                    f"{self.task_info['method']}. "
+                    "Please select task with method buildArch."),
                 status_code=HTTPStatus.BAD_REQUEST,
             )
 


### PR DESCRIPTION
if a koji build fails, sadly this doesn't do anything:

    koji_logs = self.client.getBuildLogs(self.build_or_task_id)

koji api docs:

> This method will only return logs for builds that are complete.
> If a build is in progress, failed, or canceled, you must look at the
> build's task logs instead (see listTaskOutput).

Instead, we need to manually traverse the task hierarchy and select the
right buildArch task, which this commit implements.