### PR TITLE
improve UX of progress bar

### DIFF
--- a/backend/store.py
+++ b/backend/store.py
@@ -35,7 +35,7 @@ class Storator3000:
     @classmethod
     def get_logs(cls) -> list:
         if not os.path.exists(FEEDBACK_DIR):
-            raise NoDataFound(f"Directory doesn't exist: {FEEDBACK_DIR}")
+            return []
 
         all_files = [[
                         os.path.join(subdir[0], file)

--- a/frontend/public/css/style.css
+++ b/frontend/public/css/style.css
@@ -295,7 +295,7 @@ a:hover {
   position: absolute;
   margin-left: auto;
   margin-right: auto;
-  margin-top: 3px;
+  margin-top: 0px;
   left: 0;
   right: 0;
   text-align: center;

--- a/frontend/public/documentation.html
+++ b/frontend/public/documentation.html
@@ -62,6 +62,15 @@ We plan to add a review tool to Log Detective. Similarly what <a href="https://c
     </div>
 
     <h2 class="text-center">FAQ</h2>
+
+    <div class="card">
+      <div class="card-body">
+        <a id="goals" />
+        <h5 class="card-title">What is our first goal?</h5>
+Our first step is to collect 1000 annotated logs. This is the estimated amount we need to start producing useful results when training AI. After we reach this goal, we will begin working on a CLI tool that will use the trained data. We will then continue to collect data as 2-3 thousands samples should be needed to get satisfactionary results.
+      </div>
+    </div>
+
     <div class="card">
       <div class="card-body">
         <h5 class="card-title">What AI model are you using?</h5>

--- a/frontend/src/app/homepage.cljs
+++ b/frontend/src/app/homepage.cljs
@@ -101,12 +101,15 @@
        @report-target)) 100)) 100))
 
 (defn render-stats []
-  [:div {:id "progressbar"}
-   [:h5 "Are we there yet?"]
-   [:div {:id "progressbar-number"}
-    [:p (progress-width) "%"]]
-   [:div {:id "progress"
-          :style {:width (str (progress-width) "%")}}]])
+  [:<>
+   [:div {:id "progressbar"}
+    [:p {:id "progressbar-number"} (str (progress-width) "%")]
+    [:div {:id "progress"
+           :style {:width (str (progress-width) "%")}}]
+    [:div {:id "progressbar2"}
+     [:div
+      [:p "Collected " (:total_reports @backend-stats) " logs from "
+       [:a {:href "/documentation#goals"} @report-target]]]]]])
 
 (defn render-card [provider url title img text inputs]
   [:div {:class "card-body"}


### PR DESCRIPTION
This should improve UX of progress bar and make clear, what the progress display, what is 100% and links to documentation.

Note that this is completely untested as I unable to run pre-commit hook and neither run podman-compose (it again does not display the central box for me).