### PR TITLE
frontend: remember the username and prefill it the next time

### DIFF
--- a/frontend/src/app/contribute.cljs
+++ b/frontend/src/app/contribute.cljs
@@ -26,6 +26,7 @@
      error-title
      backend-data
      log
+     fas
      build-id
      build-id-title
      build-url]]
@@ -148,6 +149,7 @@
     [:input {:type "text"
              :class "form-control"
              :placeholder "Optional - Your FAS username"
+             :value (or @fas (.getItem js/localStorage "fas"))
              :on-change #(on-change-fas %)}]]
 
    [:label {:class "form-label"} "Interesting snippets:"]

--- a/frontend/src/app/contribute_events.cljs
+++ b/frontend/src/app/contribute_events.cljs
@@ -54,6 +54,11 @@
                    (:logs @backend-data))
               :spec_file @spec
               :container_file @container}]
+
+    ;; Remember the username, so we can prefill it the next time
+    (when @fas
+      (.setItem js/localStorage "fas" @fas))
+
     (reset! status "submitting")
     (-> (fetch/post url {:accept :json :content-type :json :body body})
         (.then (fn [resp] (-> resp :body (js->clj :keywordize-keys true))))


### PR DESCRIPTION
Fix #101

We are storing the value into `localStorage` instead cookies, so that nothing is on the server and we don't have to show the annoying "accept cookies" dialog.

https://www.w3schools.com/jsref/prop_win_localstorage.asp