### PR TITLE
frontend: always calculate the snippet indexes from the beginning

### DIFF
--- a/frontend/src/app/contribute_events.cljs
+++ b/frontend/src/app/contribute_events.cljs
@@ -44,7 +44,7 @@
                                  (rename-keys {:comment :user_comment
                                                :start-index :start_index
                                                :end-index :end_index})
-                                 (dissoc :text :file)))
+                                 (dissoc :file)))
                             ;; Only snippets for this file
                            (filter
                             (fn [snippet]

--- a/frontend/src/app/helpers.cljs
+++ b/frontend/src/app/helpers.cljs
@@ -10,3 +10,9 @@
 
 (defn remove-trailing-slash [text]
   (clojure.string/replace text #"/$" ""))
+
+(defn previous-siblings [node]
+  (let [sibling (.-previousSibling node)]
+    (if-not sibling
+      []
+      (conj (previous-siblings sibling) sibling))))


### PR DESCRIPTION
We have been collecting incorrect indexes. They aren't calculated from the end of the log but rather from the end of the previous node.

I am currently working on fixing our collected data.