### PR TITLE
Fix downloading results

### DIFF
--- a/.github/workflows/python-diff-lint.yml
+++ b/.github/workflows/python-diff-lint.yml
@@ -18,6 +18,7 @@ jobs:
         id: VCS_Diff_Lint
         with:
           subdirectory: backend
+          install_rpm_packages: ["python3-starlette"]
 
       - name: Upload artifact with detected defects in SARIF format
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
I had to rewrite the function from an async implementataion that stopped
working (probably after an update to fastapi and starlette).

Fixes: https://github.com/fedora-copr/log-detective-website/issues/157