### PR TITLE
docker: add standard uvicorn as dep to support websocket

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -17,7 +17,7 @@ RUN dnf -y update && \
     # The dependencies for this project
     && dnf -y install \
                    python3-fastapi \
-                   python3-uvicorn \
+                   python3-uvicorn+standard \
                    python3-jinja2 \
                    python3-requests \
                    python3-koji \

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -30,7 +30,7 @@ ENV STORAGE_DIR=/persistent
 ENV FEEDBACK_DIR=/persistent/results
 
 RUN dnf -y install python3-fastapi \
-                   python3-uvicorn \
+                   python3-uvicorn+standard \
                    python3-gunicorn \
                    python3-jinja2 \
                    python3-requests \


### PR DESCRIPTION
Fixes #133