### PR TITLE
ci: fix the vcs-diff-lint integration

### DIFF
--- a/.github/workflows/python-diff-lint.yml
+++ b/.github/workflows/python-diff-lint.yml
@@ -18,7 +18,8 @@ jobs:
         id: VCS_Diff_Lint
         with:
           subdirectory: backend
-          install_rpm_packages: ["python3-starlette"]
+          install_rpm_packages: |
+            python3-starlette
 
       - name: Upload artifact with detected defects in SARIF format
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The install_rpm_packages option accepts a list as a space-separated string.